### PR TITLE
Adds initial support for docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:12-alpine
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --production
+RUN yarn global add serve
+COPY . .
+RUN yarn build
+CMD serve -s build


### PR DESCRIPTION
Dockerfile - builds the project, serves it via port 5000 by default
.dockerignore - no need to mount local node_modules

Thoughts on this? May be useful if anyone wants to run it locally.